### PR TITLE
Extend context menu

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -245,18 +245,6 @@
       }
     }
   },
-  "moveTabGroupToNewWindow": {
-    "message": "Move Grouped Tabs to New Window"
-  },
-  "moveTabGroupToNewWindow_title": {
-    "message": "Move Grouped Tabs to New Window $KEY$",
-    "placeholders": {
-      "key" : {
-        "content" : "$1",
-        "example" : "(W)"
-      }
-    }
-  },
   "muteAudio": {
     "message": "Mute Audio"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -245,18 +245,6 @@
       }
     }
   },
-  "moveTabGroupToNewWindow": {
-    "message": "グループのタブを新しいウィンドウへ移動"
-  },
-  "moveTabGroupToNewWindow_title": {
-    "message": "グループのタブを新しいウィンドウへ移動 $KEY$",
-    "placeholders": {
-      "key" : {
-        "content" : "$1",
-        "example" : "(W)"
-      }
-    }
-  },
   "muteAudio": {
     "message": "タブをミュート"
   },

--- a/src/html/sidebar.html
+++ b/src/html/sidebar.html
@@ -141,14 +141,6 @@
                 Bookmark Grouped Tabs
               </span>
             </li>
-            <li id="sidebar-tabs-menu-tab-group-new-win-move"
-                tabindex="0" accesskey="N">
-              <span class="menu-item-label"
-                    title="Move Grouped Tabs to New Window"
-                    data-i18n="moveTabGroupToNewWindow">
-                Move Grouped Tabs to New Window
-              </span>
-            </li>
             <li class="menu-separator"></li>
             <li id="sidebar-tabs-menu-tab-group-detach"
                 tabindex="0" accesskey="T">

--- a/src/js/sidebar.js
+++ b/src/js/sidebar.js
@@ -62,7 +62,7 @@
   const MENU_TAB_GROUP_SELECTED = "sidebar-tabs-menu-tab-group-selected";
   const MENU_TAB_GROUP_SYNC = "sidebar-tabs-menu-tab-group-sync";
   const MENU_TAB_GROUP_UNGROUP = "sidebar-tabs-menu-tab-group-ungroup";
-  const MENU_TAB_NEW_WIN_MOVE = "sidebar-tabs-menu-tab-new-win-move";
+  const MENU_TAB_MOVE_WIN_NEW = "sidebar-tabs-menu-tab-new-win-move";
   const MENU_TAB_PIN = "sidebar-tabs-menu-tab-pin";
   const MENU_TAB_RELOAD = "sidebar-tabs-menu-tab-reload";
   const MENU_TAB_SYNC = "sidebar-tabs-menu-tab-sync";
@@ -75,7 +75,6 @@
   const MIME_TYPE = "text/plain";
   const MOUSE_BUTTON_RIGHT = 2;
   const NEW_TAB = "newtab";
-  const NEW_WIN_MOVE = "moveToNewWindow";
   const PINNED = "pinned";
   const SIDEBAR_INIT = "initSidebar";
   const SIDEBAR_OPT = "sidebarTabsOptions";
@@ -102,6 +101,7 @@
   const TAB_GROUP_UNGROUP = "ungroupTabs";
   const TAB_LIST = "tabList";
   const TAB_OBSERVE = "observeTab";
+  const TAB_MOVE_WIN_NEW = "moveTabToNewWindow";
   const TAB_PIN = "pinTab";
   const TAB_PIN_UNPIN = "unpinTab";
   const TAB_RELOAD = "reloadTab";
@@ -2110,7 +2110,7 @@
         }
         break;
       }
-      case MENU_TAB_NEW_WIN_MOVE:
+      case MENU_TAB_MOVE_WIN_NEW:
         if (Number.isInteger(tabId)) {
           func.push(createNewWindow({
             tabId,
@@ -2253,9 +2253,9 @@
               enabled: false,
               onclick: true,
             },
-            [NEW_WIN_MOVE]: {
-              id: MENU_TAB_NEW_WIN_MOVE,
-              title: i18n.getMessage(`${NEW_WIN_MOVE}_title`, "(W)"),
+            [TAB_MOVE_WIN_NEW]: {
+              id: MENU_TAB_MOVE_WIN_NEW,
+              title: i18n.getMessage(`${TAB_MOVE_WIN_NEW}_title`, "(N)"),
               contexts: [CLASS_TAB, CLASS_TAB_GROUP],
               type: "normal",
               enabled: false,
@@ -2581,12 +2581,12 @@
       const tabMenu = menuItems.sidebarTabs.subItems[TAB];
       const tabKeys = [
         AUDIO_MUTE,
-        NEW_WIN_MOVE,
         TABS_CLOSE_END,
         TABS_CLOSE_OTHER,
         TAB_BOOKMARK,
         TAB_CLOSE,
         TAB_DUPE,
+        TAB_MOVE_WIN_NEW,
         TAB_PIN,
         TAB_RELOAD,
         TAB_SYNC,


### PR DESCRIPTION
Fix #25

Note:
* `Mute Grouped Tabs` not implemented -> It should be done individually.
* `Move Grouped Tabs to New Window` not implemented -> No api to move multiple tabs in WebExtensions. It only accepts 1 tabId `windows.create({tabId})`.
