### PR TITLE
restore context menu on port connected

### DIFF
--- a/src/mjs/background-main.js
+++ b/src/mjs/background-main.js
@@ -8,6 +8,7 @@ import {
   getType, isObjectNotEmpty, isString, logErr, throwErr
 } from './common.js';
 import { ports, removePort } from './port.js';
+import { restoreContextMenu } from './menu.js';
 import { saveSessionTabList } from './session.js';
 import {
   SESSION_SAVE, SIDEBAR, SIDEBAR_STATE_UPDATE, TOGGLE_STATE
@@ -204,7 +205,7 @@ export const handleConnectedPort = async (port = {}) => {
       port.onDisconnect.addListener(portOnDisconnect);
       port.onMessage.addListener(portOnMessage);
       ports.set(portId, port);
-      await setSidebarState(windowId);
+      await setSidebarState(windowId).then(restoreContextMenu);
     }
   }
 };

--- a/src/mjs/menu.js
+++ b/src/mjs/menu.js
@@ -248,8 +248,10 @@ export const removeContextualIdentitiesMenu = async info => {
  * restore context menu
  * @returns {Promise} - promise chain
  */
-export const restoreContextMenu = async () =>
-  menus.removeAll().then(createContextMenu);
+export const restoreContextMenu = async () => {
+  await menus.removeAll();
+  return createContextMenu(menuItems);
+};
 
 /**
  * override context menu


### PR DESCRIPTION
Fix #260

It is basically upstream issue
See [1771328 - Restarting manifest v3 extension removes its context menu entry](https://bugzilla.mozilla.org/show_bug.cgi?id=1771328)

Added workaround
